### PR TITLE
Mock trainings can be replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://travis-ci.org/jonasholtkamp/jest-when-xt.svg?branch=master)](https://travis-ci.org/jonasholtkamp/jest-when-xt)
 [![codecov](https://codecov.io/gh/jonasholtkamp/jest-when-xt/branch/master/graph/badge.svg)](https://codecov.io/gh/jonasholtkamp/jest-when-xt)
 
-A fork from [jest-when](https://github.com/timkindberg/jest-when).
+A fork from @timkindberg's [jest-when](https://github.com/timkindberg/jest-when).
 
 ```
 npm i --save-dev jest-when-xt
@@ -20,6 +20,30 @@ when(fn).calledWith(1).mockReturnValue('yay!')
 const result = fn(1)
 expect(result).toEqual('yay!')
 ```
+
+#### Supports chaining of mock trainings:
+```javascript
+when(fn)
+  .calledWith(1, true).mockReturnValue('yay!')
+  .calledWith(2, false).mockReturnValue('nay!')
+
+expect(fn(1, true)).toEqual('yay!')
+expect(fn(2, false)).toEqual('nay!')
+```
+Thanks to @kernelkiller.
+
+#### Supports replacement of mock trainings:
+```javascript
+when(fn).calledWith(1, true).mockReturnValue('yay!')
+expect(fn(1, true)).toEqual('yay!')
+
+when(fn).calledWith(2, false).mockReturnValue('nay!')
+expect(fn(2, false)).toEqual('nay!')
+```
+This replacement of the training does only happen for mock functions _not_ ending in `*Once`. 
+Trainings like `mockReturnValueOnce` are removed after a matching function call anyway.
+
+Thanks to @kernelkiller.
 
 #### Supports multiple args:
 ```javascript
@@ -106,3 +130,6 @@ when(fn).expectCalledWith(1).mockReturnValue('x')
 fn(2); // Will throw a helpful jest assertion error with args diff
 ```
 
+### Contributors
+* @timkindberg (original author)
+* @kernelkiller

--- a/src/when.js
+++ b/src/when.js
@@ -27,7 +27,10 @@ class WhenMock {
     this.callMocks = []
 
     const mockReturnValue = (matchers, assertCall, once = false) => (val) => {
-      this.callMocks.push({ matchers, val, assertCall, once })
+      // Remove call mocks with equal matchers to enable dynamic replacement during a test
+      this.callMocks = this.callMocks
+        .filter((callMock) => once || !utils.equals(callMock.matchers, matchers))
+        .concat({ matchers, val, assertCall, once })
 
       this.fn.mockImplementation((...args) => {
         logger.debug('mocked impl', args)
@@ -49,6 +52,8 @@ class WhenMock {
           }
         }
       })
+
+      return this
     }
 
     const mockReturnValueOnce = (matchers, assertCall) => (val) =>

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -91,6 +91,35 @@ describe('When', () => {
       expect(fn(false, /asdf/g)).toEqual('z')
     })
 
+    it('supports chaining of when declarations', () => {
+      const fn = jest.fn()
+
+      const result = when(fn)
+        .calledWith(1)
+        .mockReturnValue('x')
+
+      expect(result).toBeInstanceOf(WhenMock)
+
+      when(fn).calledWith('foo', 'bar')
+        .mockReturnValue('y')
+        .calledWith(false, /asdf/g)
+        .mockReturnValue('z')
+
+      expect(fn(1)).toEqual('x')
+      expect(fn('foo', 'bar')).toEqual('y')
+      expect(fn(false, /asdf/g)).toEqual('z')
+    })
+
+    it('supports replacement of when declarations', () => {
+      const fn = jest.fn()
+
+      when(fn).calledWith('foo', 'bar').mockReturnValue('x')
+      when(fn).calledWith(false, /asdf/g).mockReturnValue('y')
+      when(fn).calledWith('foo', 'bar').mockReturnValue('z')
+
+      expect(fn('foo', 'bar')).toEqual('z')
+    })
+
     it('returns a declared value repeatedly', () => {
       const fn = jest.fn()
 


### PR DESCRIPTION
Resolves #2 and timkindberg/jest-when#2

@kernelkiller: If you'd be so kind, please have a look on this PR. I forked the original repository because of so little activity and incorporated your proposed changes regarding chaining and replacements.

If you'd _then_ be so kind again, you can have a look on #4 as well :)